### PR TITLE
read oracle user and password from configs

### DIFF
--- a/presto-docs/src/main/sphinx/connector/oracle.rst
+++ b/presto-docs/src/main/sphinx/connector/oracle.rst
@@ -41,6 +41,12 @@ for more information.
 The ``connection-user`` and ``connection-password`` are typically required and
 determine the user credentials for the connection, often a service user.
 
+.. note::
+
+   The user and password can be set either in the connection URL or in the ``connection-user`` and ``connection-password`` properties. Providing the credentials in both places will result in an error.
+
+
+
 Multiple Oracle Servers
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClientModule.java
+++ b/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClientModule.java
@@ -58,10 +58,9 @@ public class OracleClientModule
     {
         requireNonNull(config, "BaseJdbc config is null");
 
-        boolean isCredentialsInUrl = JDBCUrlValidator.checkCredentialsInJdbcUrl(config.getConnectionUrl());
-        // Throws an exception when username and password present in both connection url and configs
+        boolean isCredentialsInUrl = JDBCUrlValidator.findCredentialsInJdbcUrl(config.getConnectionUrl());
         if (isCredentialsInUrl && (config.getConnectionUser() != null || config.getConnectionPassword() != null)) {
-            throw new PrestoException(NOT_SUPPORTED, "User credentials in both configs and url");
+            throw new PrestoException(NOT_SUPPORTED, "Credentials are specified in both connection-url and user/password properties. Use only one");
         }
         Properties connectionProperties = basicConnectionProperties(config);
         connectionProperties.setProperty(OracleConnection.CONNECTION_PROPERTY_INCLUDE_SYNONYMS, String.valueOf(oracleConfig.isSynonymsEnabled()));
@@ -73,13 +72,12 @@ public class OracleClientModule
                 Optional.empty(),
                 connectionProperties);
     }
+
     public static class JDBCUrlValidator
     {
-        //To check the presence of username and password in the connection url
-        public static boolean checkCredentialsInJdbcUrl(String jdbcUrl)
+        public static boolean findCredentialsInJdbcUrl(String jdbcUrl)
         {
-            String regex = "jdbc:oracle:thin:([^/]+?)/([^@]+?)@";
-
+            String regex = "jdbc:oracle:thin:[^@]+@";
             Pattern pattern = Pattern.compile(regex);
             Matcher matcher = pattern.matcher(jdbcUrl);
 

--- a/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/OracleClientModuleTest.java
+++ b/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/OracleClientModuleTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.oracle;
+
+import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
+import com.facebook.presto.spi.PrestoException;
+import org.testng.annotations.Test;
+
+import java.sql.SQLException;
+
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static com.facebook.presto.testing.assertions.Assert.fail;
+
+public class OracleClientModuleTest
+{
+    @Test
+    public void testConnectionFactory_credentialsInUrlAndConfig() throws SQLException
+    {
+        BaseJdbcConfig config = new BaseJdbcConfig();
+
+        // Credentials in both config and URL
+        config.setConnectionUrl("jdbc:oracle:thin:user/pass@localhost:1521/database");
+        config.setConnectionUser("user");
+        config.setConnectionPassword("pass");
+
+        OracleConfig oracleConfig = new OracleConfig();
+        oracleConfig.setSynonymsEnabled(true);
+
+        try {
+            OracleClientModule.connectionFactory(config, oracleConfig);
+            fail("Expected SQLException to be thrown");
+        }
+        catch (PrestoException e) {
+            assertEquals("Credentials are specified in both connection-url and user/password properties. Use only one", e.getMessage());
+        }
+
+        // User in URL and password in config
+        config.setConnectionUrl("jdbc:oracle:thin:user/@localhost:1521/database");
+        config.setConnectionUser(null);
+        config.setConnectionPassword("pass");
+
+        try {
+            OracleClientModule.connectionFactory(config, oracleConfig);
+            fail("Expected SQLException to be thrown");
+        }
+        catch (PrestoException e) {
+            assertEquals("Credentials are specified in both connection-url and user/password properties. Use only one", e.getMessage());
+        }
+        // User in config and password in URL
+        config.setConnectionUrl("jdbc:oracle:thin:/pass@localhost:1521/database");
+        config.setConnectionUser("user");
+        config.setConnectionPassword(null);
+
+        try {
+            OracleClientModule.connectionFactory(config, oracleConfig);
+            fail("Expected SQLException to be thrown");
+        }
+        catch (PrestoException e) {
+            assertEquals("Credentials are specified in both connection-url and user/password properties. Use only one", e.getMessage());
+        }
+
+        // Credentials in URL, not in config
+        config.setConnectionUrl("jdbc:oracle:thin:user/pass@localhost:1521/database");
+        config.setConnectionUser(null);
+        config.setConnectionPassword(null);
+
+        try {
+            OracleClientModule.connectionFactory(config, oracleConfig);
+        }
+        catch (PrestoException e) {
+            fail("Expected no exception but got this" + e.getMessage());
+        }
+
+        // Credentials in config, not in URL
+        config.setConnectionUrl("jdbc:oracle:thin:@localhost:1521/database");
+        config.setConnectionUser("user");
+        config.setConnectionPassword("pass");
+
+        try {
+            OracleClientModule.connectionFactory(config, oracleConfig);
+        }
+        catch (PrestoException e) {
+            fail("Expected no exception but got this: " + e.getMessage());
+        }
+
+        // No credentials in either config or URL
+        config.setConnectionUrl("jdbc:oracle:thin:@localhost:1521/database");
+        config.setConnectionUser(null);
+        config.setConnectionPassword(null);
+
+        try {
+            OracleClientModule.connectionFactory(config, oracleConfig);
+        }
+        catch (PrestoException e) {
+            fail("Expected no exception, but got: " + e.getMessage(), e);
+        }
+    }
+}

--- a/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestOraclePlugin.java
+++ b/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/TestOraclePlugin.java
@@ -28,6 +28,6 @@ public class TestOraclePlugin
     {
         Plugin plugin = new OraclePlugin();
         ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
-        factory.create("test", ImmutableMap.of("connection-url", "jdbc:oracle:thin//test"), new TestingConnectorContext());
+        factory.create("test", ImmutableMap.of("connection-url", "jdbc:oracle:thin//test", "connection-user", "admin", "connection-password", "password"), new TestingConnectorContext());
     }
 }


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Currently we are passing username and password in the connection URL in oracle. But it is better to use the existing basejdbc configs for username and password. This PR is to make changes to use username and password configs for oracle.
## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... :pr:`12345`
* ... :pr:`12345`

Hive Connector Changes
* ... :pr:`12345`
* ... :pr:`12345`
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

